### PR TITLE
fix: Bootstrap add page call

### DIFF
--- a/classes/Bootstrap.php
+++ b/classes/Bootstrap.php
@@ -24,7 +24,7 @@ class Bootstrap implements BootstrapInterface {
 	 */
 	private function __construct() {
 		ContentSecurityPolicy::init();
-		add_action( 'acf/init', '\Jcore\Security\Bootstrap::add_menu_page' );
+		self::add_menu_page();
 	}
 
 	/**


### PR DESCRIPTION
Since bootstrap needs to be called in a later hook, the constructor can call the add_menu_page() directly.